### PR TITLE
Modify norm constraints

### DIFF
--- a/tensorMCCA/R/mCCA.single.cor.R
+++ b/tensorMCCA/R/mCCA.single.cor.R
@@ -10,7 +10,7 @@
 # The optimization is conducted one data block at a time
 	
 mCCA.single.cor <- function(x, v, c, maxit = 1000, tol = 1e-6, 
-	balance = TRUE, verbose = TRUE)
+	balance, verbose)
 {
 	
 ## Data dimensions
@@ -20,7 +20,6 @@ ndim.img <- ndimx - 1
 m <- length(x)
 n <- dimx[[1]][ndimx[1]]
 
-debug <- FALSE
 objective <- numeric(maxit+1)
 objective[1] <- objective.internal(x, v, c)
 if (verbose) 
@@ -31,8 +30,8 @@ for (it in 1:maxit) {
 	for (i in 1:m) { 		
 		## Calculate/update objective weights w_jt = <X_jt, v_j> 
 		## After the first algorithm iteration (it = 1), in each 
-		## iteration of the i loop, only the w_{i-1,t}, t=1:n, 
-		## (resp. the w_mt, t=1:n) need updating if i > 1 (resp. i = 1)
+		## iteration of the i loop, only w_{i-1,t}, t=1:n, 
+		## (resp. w_mt, t=1:n) need updating if i > 1 (resp. i = 1)
 		idxj <- if (it == 1 && i == 1) {
 			2:m } else if (i == 1) { m 
 			} else (i-1)
@@ -61,44 +60,11 @@ for (it in 1:maxit) {
 		dim(a) <- dimx[[i]][-ndimx[i]]
 		
 		## Update canonical vectors
-		v[[i]] <- optim.cor(v[[i]], a, x[[i]], maxit, tol, debug = debug)				
-	}					
-
-	# for (i in 1:m) { 		
-		# ## Calculate objective weights 
-		# ## w_jt = <X_jt, v_j> (j != i, t = 1,...,n)
-		# w <- matrix(0, m, n)
-		# for (j in (1:m)[-i]) {
-			# iprod <- x[[j]]
-			# if (ndim.img[j] == 1) { # 1D case
-				# w[j,] <- c[i,j] * crossprod(v[[j]][[1]], iprod) 
-			# } else if (ndim.img[j] == 2) { # 2D case
-				# dim(iprod) <- c(dimx[[j]][1], prod(dimx[[j]][-1]))
-				# iprod <- crossprod(v[[j]][[1]], iprod)
-				# dim(iprod) <- c(dimx[[j]][2], n) 
-				# w[j,] <- c[i,j] * crossprod(v[[j]][[2]], iprod) 
-			# } else { # 3D case
-				# dim(iprod) <- c(dimx[[j]][1], prod(dimx[[j]][-1]))
-				# iprod <- crossprod(v[[j]][[1]], iprod)
-				# dim(iprod) <- c(dimx[[j]][2], dimx[[j]][3] * n)
-				# iprod <- crossprod(v[[j]][[2]], iprod)
-				# dim(iprod) <- c(dimx[[j]][3], n) 
-				# w[j,] <- c[i,j] * crossprod(v[[j]][[3]], iprod)
-			# }
-		# }
-		# w <- colSums(w) / n
-		# a <- x[[i]]		
-		# dim(a) <- c(prod(dimx[[i]][-ndimx[i]]), n)
-		# a <- a %*% w
-		# dim(a) <- dimx[[i]][-ndimx[i]]
-		
-		# ## Update canonical vectors
-		# v[[i]] <- optim.cor(v[[i]], a, x[[i]], maxit, tol, debug = debug)				
-	# }					
+		v[[i]] <- optim.cor(v[[i]], a, x[[i]], maxit, tol)				
+	}								
 	
 	## Calculate objective value (sum of correlations)
-	y <- image.scores(x, v)	 # y_it = < v_i, x_it > 
-	objective[it+1] <- sum(c * crossprod(y)) / n	
+	objective[it+1] <- objective.internal(x, v, c)	
 
 	if (verbose) 
 		cat("\nIteration",it,"Objective",objective[it+1])
@@ -108,7 +74,7 @@ for (it in 1:maxit) {
 	if (balance) {
 		for (i in 1:m) {
 			nrm <- sapply(v[[i]], function(x) sqrt(sum(x^2)))
-			if (any(nrm == 0)) next
+			if (any(nrm < 1e-15)) next
 			d <- length(nrm)
 			s <- prod(nrm)^(1/d) / nrm
 			for (k in 1:d)
@@ -121,9 +87,8 @@ for (it in 1:maxit) {
 	    	tol * max(1,objective[it])) break
 }
 
-
-list(v = v, y = y, objective = objective[it+1], iters = it, 
-	trace = objective[1:(it+1)])
+list(v = v, y = image.scores(x, v), objective = objective[it+1], 
+	iters = it, trace = objective[1:(it+1)])
 
 }
 

--- a/tensorMCCA/R/optim.block.cor.R
+++ b/tensorMCCA/R/optim.block.cor.R
@@ -30,7 +30,7 @@ list(v)
 
 ##########################################
 # Maximize bilinear form v1' A v2 under
-# constraint sum_t (v1' Bt v2)^2 = 1
+# constraint (1/n) sum_t (v1' Bt v2)^2 = 1
 ##########################################
 
 
@@ -39,58 +39,32 @@ list(v)
 ## a:	objective (2D matrix)
 ## b:	constraints (3D array)
 
-optim2D.cor <- function(v, a, b, maxit = 1000, tol = 1e-6, debug = TRUE)
+optim2D.cor <- function(v, a, b, maxit = 1000, tol = 1e-6)
 {
 	
 ## Data dimensions
-dimv <- sapply(v,length)
 dimb <- dim(b)
-p <- dimv[1]
-q <- dimv[2]
+p <- dimb[1:2]
 n <- dimb[3]
-
-## Check compatibility of dimensions
-stopifnot(identical(dim(a),dimv))
-stopifnot(identical(dim(b)[1:2],dimv))
-
 
 ## MAIN LOOP
 objective <- numeric(maxit)
-# browser()
 for (it in 1:maxit) {
 
 	## Update canonical vector in dimension 1 
 	c <- a %*% v[[2]]
-	d <- matrix(0, p, n)
+	d <- matrix(0, p[1], n)
 	for (t in 1:n) d[,t] <- b[,,t] %*% v[[2]]
-	# sigma <- tcrossprod(d) / n
-	# v[[1]] <- tryCatch(solve(sigma, c), error = function(e) numeric(0))
-	# if (length(v[[1]]) == 0) v[[1]] <- ginv(sigma) %*% c
-	# cp <- as.numeric(crossprod(v[[1]], sigma %*% v[[1]]))
-	# v[[1]] <- v[[1]] / sqrt(cp)
 	v[[1]] <- unlist(optim1D.cor(c, d))
-	
-	if (debug) {
-		check1 <- crossprod(c, v[[1]]) # debugging == sqrt(cp) ?
-		cat("\n In optim2D.cor Iteration",it,"Objective",check1)
-	}
-	
+		
 	## Update canonical vector in dimension 2
 	c <- crossprod(a, v[[1]])
-	d <- matrix(0, q, n)
+	d <- matrix(0, p[2], n)
 	for (t in 1:n) d[,t] <- crossprod(b[,,t], v[[1]])
-	# sigma <- tcrossprod(d) / n
-	# v[[2]] <- tryCatch(solve(sigma, c), error = function(e) numeric(0))
-	# if (length(v[[2]]) == 0) v[[2]] <- ginv(sigma) %*% c
-	# cp <- as.numeric(crossprod(v[[2]], c))
-	# if (cp > 0) v[[2]] <- v[[2]] / sqrt(cp)
 	v[[2]] <- unlist(optim1D.cor(c, d))
 	
 	## Calculate objective
-	objective[it] <- crossprod(c, v[[2]]) # = sqrt(cp) ?
-	if (debug) {
-		cat(" ", objective[it])
-	}
+	objective[it] <- crossprod(c, v[[2]])
 	
 	## Check convergence 
 	if (it > 1 && abs(objective[it]-objective[it-1]) <= 
@@ -106,7 +80,7 @@ return(v)
 ###################################################
 # Maximize inner product of rank-1 3D tensor 
 # with fixed 3D tensor under quadratic constraints
-# max < v,a > subject to sum_t (< v,b(t) >)^2 = 1
+# max < v,a > subject to (1/n) sum_t (< v,b(t) >)^2 = 1
 ###################################################
 
 
@@ -115,21 +89,13 @@ return(v)
 ## a:	objective (3D array) 
 ## b:	constraints (4D array) 
 
-optim3D.cor <- function(v, a, b, maxit = 1000, tol = 1e-6, debug = TRUE)
+optim3D.cor <- function(v, a, b, maxit = 1000, tol = 1e-6)
 {
 	
 ## Data dimensions
-dimv <- sapply(v, length)
 dimb <- dim(b)
-p <- dimv[1]
-q <- dimv[2]
-r <- dimv[3]
+p <- dimb[1:3]
 n <- dimb[4]
-
-## Check compatibility of dimensions
-stopifnot(identical(dim(a),dimv))
-stopifnot(identical(dim(b)[1:3],dimv))
-
 
 ## MAIN LOOP
 objective <- numeric(maxit)
@@ -137,64 +103,37 @@ objective <- numeric(maxit)
 for (it in 1:maxit) {
 
 	## Update canonical vector in dimension 1 
-	c <- numeric(p)
-	d <- matrix(0,p,n)
-	for (i in 1:p) { 
+	c <- numeric(p[1])
+	d <- matrix(0, p[1], n)
+	for (i in 1:p[1]) { 
 		c[i] <- crossprod(v[[2]], a[i,,] %*% v[[3]])
 		for (t in 1:n) 
 			d[i,t] <- crossprod(v[[2]], b[i,,,t] %*% v[[3]])
 	}
-		# sigma <- tcrossprod(d) / n
-		# v[[1]] <- tryCatch(solve(sigma, c), error = function(e) numeric(0))
-		# if (length(v[[1]]) == 0) v[[1]] <- ginv(sigma) %*% c
-		# cp <- as.numeric(crossprod(v[[1]], sigma %*% v[[1]]))
-		# if (cp > 0) v[[1]] <- v[[1]] / sqrt(cp)
 	v[[1]] <- unlist(optim1D.cor(c, d))
-	if (debug) {
-		check1 <- crossprod(c, v[[1]]) # debugging == sqrt(cp) ?
-		cat("\nIn optim3D.cor Iteration",it,"Objective",check1)
-	}
 	
 	## Update canonical vector in dimension 2
-	c <- numeric(q)
-	d <- matrix(0,q,n)
-	for (j in 1:q) { 
+	c <- numeric(p[2])
+	d <- matrix(0, p[2], n)
+	for (j in 1:p[2]) { 
 		c[j] <- crossprod(v[[1]], a[,j,] %*% v[[3]])
 		for (t in 1:n) 
 			d[j,t] <- crossprod(v[[1]], b[,j,,t] %*% v[[3]])
 	}
 	v[[2]] <- unlist(optim1D.cor(c, d))
-		# sigma <- tcrossprod(d) / n
-		# v[[2]] <- tryCatch(solve(sigma, c), error = function(e) numeric(0))
-		# if (length(v[[2]]) == 0) v[[2]] <- ginv(sigma) %*% c
-		# cp <- as.numeric(crossprod(v[[2]], sigma %*% v[[2]]))
-		# if (cp > 0) v[[2]] <- v[[2]] / sqrt(cp)
-	
-	if (debug) {
-		check2 <- crossprod(c, v[[2]]) # debugging == sqrt(cp)
-		cat(" ",check2)
-	}
 
 	## Update canonical vector in dimension 3
-	c <- numeric(r)
-	d <- matrix(0,r,n)
-	for (k in 1:r) { 
+	c <- numeric(p[3])
+	d <- matrix(0, p[3], n)
+	for (k in 1:p[3]) { 
 		c[k] <- crossprod(v[[1]], a[,,k] %*% v[[2]])
 		for (t in 1:n) 
 			d[k,t] <- crossprod(v[[1]], b[,,k,t] %*% v[[2]])
 	}
 	v[[3]] <- unlist(optim1D.cor(c, d))
-		# sigma <- tcrossprod(d) / n
-		# v[[3]] <- tryCatch(solve(sigma, c), error = function(e) numeric(0))
-		# if (length(v[[3]]) == 0) v[[3]] <- ginv(sigma) %*% c
-		# cp <- as.numeric(crossprod(v[[3]], sigma %*% v[[3]]))
-		# if (cp > 0) v[[3]] <- v[[3]] / sqrt(cp)
 
 	## Calculate objective
 	objective[it] <- crossprod(c, v[[3]]) # == sqrt(cp)
-	if (debug) {
-		cat(" ", objective[it])
-	}
 	
 	## Check convergence 
 	if (it > 1 && abs(objective[it]-objective[it-1]) <= 
@@ -210,14 +149,14 @@ return(v)
 ####################################
 
 
-optim.cor <- function(v, a, b, maxit = 1000, tol = 1e-6, debug = TRUE)
+optim.cor <- function(v, a, b, maxit = 1000, tol = 1e-6)
 {
 if (length(v) == 1) {
 	optim1D.cor(a, b)
 } else if (length(v) == 2) {
-	optim2D.cor(v, a, b, maxit, tol, debug)
+	optim2D.cor(v, a, b, maxit, tol)
 } else {
-	optim3D.cor(v, a, b, maxit, tol, debug)
+	optim3D.cor(v, a, b, maxit, tol)
 }
 }
 

--- a/tensorMCCA/R/scaling.R
+++ b/tensorMCCA/R/scaling.R
@@ -63,9 +63,6 @@ if (type == "norm" && scope == "block") {
 ## rescale each canonical vector in a given mode/dimension
 ## by the global norm of all canonical vectors in this mode
 if (type == "norm" && scope == "global") {
-	avg.nrm <- sqrt(mean(nrmt^2))
-	if (avg.nrm < 1e-15) break
-
 	## Find global scaling constant
 	coefs <- numeric(max(d)+1)
 	coefs[1] <- -m


### PR DESCRIPTION
1. In the scaling function 'scale.v' the norm constraints (block-level and global) have been modified to pertain to the tensor norm rather than vector norms. This is more in sync with the primary object of computations, namely canonical tensors, rather than canonical vectors. It also makes the global norm constraint less clunky. 
2. Added global scores to output of 'mCCA.cor'.
3. Moved 'scale.v' to its own file 'scaling.R'.
4. Removed the debugging option from the optimxD.cor functions (x=1,2,3). 